### PR TITLE
Use parallel to have operations done simultaneously

### DIFF
--- a/lib/vagrant-hostmanager-lite/command.rb
+++ b/lib/vagrant-hostmanager-lite/command.rb
@@ -25,8 +25,7 @@ module VagrantPlugins
         generate(@env, options[:provider].to_sym)
 
         if argv.length == 0
-          @env.active_machines.each do |active_name, active_provider|
-            puts active_name
+          Parallel.map(@env.active_machines) do |active_name, active_provider|
             machine = @env.machine(active_name, active_provider)
             update(machine)
           end

--- a/vagrant-hostmanager-lite.gemspec
+++ b/vagrant-hostmanager-lite.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |gem|
   gem.description   = %q{A Vagrant plugin that manages the /etc/hosts file within a multi-machine environment}
   gem.summary       = gem.description
 
+  gem.add_runtime_dependency "parallel", '1.10.0'
+
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']


### PR DESCRIPTION
So the ip collection and the /etc/hosts update are done
on all machines at the same time.

It saves some time, not that much but it's something.
Saved 45 seconds (of 3m30) on a 60 boxes run