### PR TITLE
Pin fog-core to 1.43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-  - 2.0.0
+  - 2.2.5
 
 script:
   - true # Integration tests cannot run on Travis... http://omerkatz.com/blog/2013/6/15/travis-ci-does-not-work-when-you-package-vagrant-boxes-as-a-build-step-yet

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.2.1'
+gem 'vagrant', :git => 'git://github.com/mitchellh/vagrant.git', :tag => 'v1.9.4'
 gem 'rake'
 gemspec

--- a/lib/vagrant-hostmanager-lite/version.rb
+++ b/lib/vagrant-hostmanager-lite/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module HostManager
-    VERSION = '0.4.2'
+    VERSION = '0.4.3'
   end
 end

--- a/vagrant-hostmanager-lite.gemspec
+++ b/vagrant-hostmanager-lite.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |gem|
   gem.description   = %q{A Vagrant plugin that manages the /etc/hosts file within a multi-machine environment}
   gem.summary       = gem.description
 
+  gem.add_runtime_dependency "fog-core", "~> 1.43.0"
+
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']


### PR DESCRIPTION
Because vagrant bundles only ruby 2.2.x and fog is dependent
on fog-core 1.44.0 that is dependent of xmlrpc 0.3.0 and only
working with ruby 2.3 and up.

Bumped to latest version of vagrant (1.9.4) ruby 2.2.5 to
make sure the it works with those commit